### PR TITLE
Setup static analysis options

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -17,6 +17,9 @@ linter:
   # TODO: add more rules
   rules:
     - always_declare_return_types
+    - always_specify_types
+    - avoid_returning_null
+    - avoid_web_libraries_in_flutter
     - cancel_subscriptions
     - close_sinks
     - comment_references


### PR DESCRIPTION
Gives a head start on #88 according to https://dart.dev/guides/language/analysis-options.
The linter options are listed here: https://dart-lang.github.io/linter/lints/.
The more static analysis rules we follow, the less need to nitpick on PRs (i.e. formatting, typos, missing modifiers etc.) and less room for bugs.