### PR TITLE
Upgrade Dart SDK to latest stable release

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -645,5 +645,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.15.0 <3.0.0"
+  dart: ">=2.15.1 <3.0.0"
   flutter: ">=2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 2.20.0+2
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.15.1 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
See https://dart.dev/null-safety/migration-guide.

Running `dart migrate` gives:
```
Migrating Scouting-Frontend

See https://dart.dev/go/null-safety-migration for a migration guide.

Analyzing project...

158 analysis issues found:
  error • Non-nullable instance field 'matchJson' must be initialized at lib/models/match_model.dart:29:3 • (not_initialized_non_nullable_instance_field)
  error • The parameter 'id' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/models/team_model.dart:40:10 • (missing_default_value_for_parameter)
  error • The parameter 'teamNumber' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/models/team_model.dart:41:10 • (missing_default_value_for_parameter)
  error • The parameter 'teamName' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/models/team_model.dart:42:10 • (missing_default_value_for_parameter)
  error • A value of type 'Null' can't be returned from the function 'isPC' because it has a return type of 'bool' at lib/views/constants.dart:47:14 • (return_of_invalid_type)
  error • The parameter 'key' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/Selector.dart:6:17 • (missing_default_value_for_parameter)
  error • The parameter 'value' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/Selector.dart:6:27 • (missing_default_value_for_parameter)
  error • The parameter 'values' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/Selector.dart:6:39 • (missing_default_value_for_parameter)
  error • The parameter 'initialValue' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/Selector.dart:6:52 • (missing_default_value_for_parameter)
  error • The parameter 'onChange' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/Selector.dart:6:71 • (missing_default_value_for_parameter)
  error • The argument type 'void Function(String)' can't be assigned to the parameter type 'void Function(String?)?' at lib/views/mobile/Selector.dart:28:18 • (argument_type_not_assignable)
  error • The parameter 'key' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/Slider.dart:7:12 • (missing_default_value_for_parameter)
  error • The parameter 'label' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/Slider.dart:8:22 • (missing_default_value_for_parameter)
  error • The parameter 'value' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/Slider.dart:9:22 • (missing_default_value_for_parameter)
  error • The parameter 'onChange' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/Slider.dart:10:12 • (missing_default_value_for_parameter)
  error • The parameter 'divisions' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/Slider.dart:11:12 • (missing_default_value_for_parameter)
  error • The parameter 'max' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/Slider.dart:12:12 • (missing_default_value_for_parameter)
  error • The parameter 'min' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/Slider.dart:13:12 • (missing_default_value_for_parameter)
  error • The parameter 'label' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/counter.dart:18:29 • (missing_default_value_for_parameter)
  error • The parameter 'icon' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/counter.dart:19:28 • (missing_default_value_for_parameter)
  error • The parameter 'count' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/counter.dart:20:28 • (missing_default_value_for_parameter)
  error • The parameter 'onChange' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/counter.dart:21:18 • (missing_default_value_for_parameter)
  error • Non-nullable instance field 'result' must be initialized at lib/views/mobile/file_picker_widget.dart:7:3 • (not_initialized_non_nullable_instance_field)
  error • The parameter 'key' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/file_picker_widget.dart:7:25 • (missing_default_value_for_parameter)
  error • The parameter 'controller' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/file_picker_widget.dart:7:45 • (missing_default_value_for_parameter)
  error • The parameter 'onImagePicked' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/file_picker_widget.dart:7:62 • (missing_default_value_for_parameter)
  error • A value of type 'FilePickerResult?' can't be assigned to a variable of type 'FilePickerResult' at lib/views/mobile/file_picker_widget.dart:26:31 • (invalid_assignment)
  error • The parameter 'key' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/firebase_submit_button.dart:16:12 • (missing_default_value_for_parameter)
  error • The parameter 'vars' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/firebase_submit_button.dart:16:22 • (missing_default_value_for_parameter)
  error • The parameter 'mutation' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/firebase_submit_button.dart:16:33 • (missing_default_value_for_parameter)
  error • The parameter 'resetForm' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/firebase_submit_button.dart:16:48 • (missing_default_value_for_parameter)
  error • The parameter 'result' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/firebase_submit_button.dart:16:64 • (missing_default_value_for_parameter)
  error • A value of type 'UploadTask?' can't be assigned to a variable of type 'UploadTask' at lib/views/mobile/firebase_submit_button.dart:105:31 • (invalid_assignment)
  error • The argument type 'Uint8List?' can't be assigned to the parameter type 'Uint8List' at lib/views/mobile/firebase_submit_button.dart:106:23 • (argument_type_not_assignable)
  error • The argument type 'String?' can't be assigned to the parameter type 'String' at lib/views/mobile/firebase_submit_button.dart:108:32 • (argument_type_not_assignable)
  error • The parameter 'key' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/match_dropdown.dart:5:21 • (missing_default_value_for_parameter)
  error • The parameter 'onChange' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/match_dropdown.dart:5:41 • (missing_default_value_for_parameter)
  error • The parameter 'controller' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/match_dropdown.dart:5:66 • (missing_default_value_for_parameter)
  error • Non-nullable instance field 'shifter' must be initialized at lib/views/mobile/pit_vars.dart:7:10 • (not_initialized_non_nullable_instance_field)
  error • Non-nullable instance field 'gearbox' must be initialized at lib/views/mobile/pit_vars.dart:8:10 • (not_initialized_non_nullable_instance_field)
  error • Non-nullable instance field 'driveWheelType' must be initialized at lib/views/mobile/pit_vars.dart:10:10 • (not_initialized_non_nullable_instance_field)
  error • Non-nullable instance field 'teamId' must be initialized at lib/views/mobile/pit_vars.dart:14:7 • (not_initialized_non_nullable_instance_field)
  error • A value of type 'Null' can't be assigned to a variable of type 'String' at lib/views/mobile/pit_vars.dart:36:15 • (invalid_assignment)
  error • A value of type 'Null' can't be assigned to a variable of type 'String' at lib/views/mobile/pit_vars.dart:37:15 • (invalid_assignment)
  error • A value of type 'Null' can't be assigned to a variable of type 'int' at lib/views/mobile/pit_vars.dart:43:14 • (invalid_assignment)
  error • Target of URI doesn't exist: 'package:scouting_frontend/views/mobile/slider.dart' at lib/views/mobile/screens/pit_view.dart:13:8 • (uri_does_not_exist)
  error • Target of URI doesn't exist: 'package:scouting_frontend/views/mobile/selector.dart' at lib/views/mobile/screens/pit_view.dart:14:8 • (uri_does_not_exist)
  error • Non-nullable instance field 'result' must be initialized at lib/views/mobile/screens/pit_view.dart:24:3 • (not_initialized_non_nullable_instance_field)
  error • Non-nullable instance field 'team' must be initialized at lib/views/mobile/screens/pit_view.dart:24:3 • (not_initialized_non_nullable_instance_field)
  error • The parameter 'key' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/screens/pit_view.dart:24:16 • (missing_default_value_for_parameter)
  error • A value of type 'Null' can't be assigned to a variable of type 'FilePickerResult' at lib/views/mobile/screens/pit_view.dart:70:14 • (invalid_assignment)
  error • The method 'Selector' isn't defined for the type 'PitView' at lib/views/mobile/screens/pit_view.dart:98:15 • (undefined_method)
  error • The method 'Selector' isn't defined for the type 'PitView' at lib/views/mobile/screens/pit_view.dart:109:15 • (undefined_method)
  error • A value of type 'String?' can't be assigned to a variable of type 'String' at lib/views/mobile/screens/pit_view.dart:145:34 • (invalid_assignment)
  error • A value of type 'String?' can't be assigned to a variable of type 'String' at lib/views/mobile/screens/pit_view.dart:165:34 • (invalid_assignment)
  error • The method 'PitViewSlider' isn't defined for the type 'PitView' at lib/views/mobile/screens/pit_view.dart:188:15 • (undefined_method)
  error • The method 'PitViewSlider' isn't defined for the type 'PitView' at lib/views/mobile/screens/pit_view.dart:201:15 • (undefined_method)
  error • The method 'PitViewSlider' isn't defined for the type 'PitView' at lib/views/mobile/screens/pit_view.dart:214:15 • (undefined_method)
  error • The parameter 'label' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/section_divider.dart:6:40 • (missing_default_value_for_parameter)
  error • The parameter 'key' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/side_nav_bar.dart:7:25 • (missing_default_value_for_parameter)
  error • Non-nullable instance field 'teamId' must be initialized at lib/views/mobile/specific_vars.dart:4:7 • (not_initialized_non_nullable_instance_field)
  error • A value of type 'Null' can't be assigned to a variable of type 'int' at lib/views/mobile/specific_vars.dart:15:14 • (invalid_assignment)
  error • The parameter 'lowerLimit' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/stepper.dart:6:20 • (missing_default_value_for_parameter)
  error • The parameter 'upperLimit' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/stepper.dart:7:20 • (missing_default_value_for_parameter)
  error • The parameter 'stepValue' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/stepper.dart:8:20 • (missing_default_value_for_parameter)
  error • The parameter 'longPressStepValue' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/stepper.dart:9:20 • (missing_default_value_for_parameter)
  error • The parameter 'iconSize' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/stepper.dart:10:20 • (missing_default_value_for_parameter)
  error • The parameter 'value' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/stepper.dart:11:20 • (missing_default_value_for_parameter)
  error • The parameter 'onChanged' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/stepper.dart:12:20 • (missing_default_value_for_parameter)
  error • The parameter 'icon' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/stepper.dart:92:23 • (missing_default_value_for_parameter)
  error • The parameter 'onPress' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/stepper.dart:93:22 • (missing_default_value_for_parameter)
  error • The parameter 'onLongPress' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/stepper.dart:94:22 • (missing_default_value_for_parameter)
  error • The parameter 'iconSize' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/stepper.dart:95:22 • (missing_default_value_for_parameter)
  error • The argument type 'Function' can't be assigned to the parameter type 'void Function()?' at lib/views/mobile/stepper.dart:108:18 • (argument_type_not_assignable)
  error • The argument type 'Function' can't be assigned to the parameter type 'void Function()?' at lib/views/mobile/stepper.dart:109:20 • (argument_type_not_assignable)
  error • The parameter 'vars' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/submit_button.dart:14:28 • (missing_default_value_for_parameter)
  error • The parameter 'mutation' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/submit_button.dart:14:39 • (missing_default_value_for_parameter)
  error • The parameter 'resetForm' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/submit_button.dart:14:54 • (missing_default_value_for_parameter)
  error • The parameter 'key' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/submit_button.dart:14:69 • (missing_default_value_for_parameter)
  error • The property 'graphqlErrors' can't be unconditionally accessed because the receiver can be 'null' at lib/views/mobile/submit_button.dart:79:49 • (unchecked_use_of_nullable_value)
  error • Non-nullable instance field 'selected' must be initialized at lib/views/mobile/switcher.dart:10:3 • (not_initialized_non_nullable_instance_field)
  error • The parameter 'labels' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/switcher.dart:11:26 • (missing_default_value_for_parameter)
  error • The parameter 'colors' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/switcher.dart:12:26 • (missing_default_value_for_parameter)
  error • The parameter 'onChange' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/switcher.dart:14:16 • (missing_default_value_for_parameter)
  error • The parameter 'key' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/team_selection_future.dart:8:28 • (missing_default_value_for_parameter)
  error • The parameter 'onChange' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/team_selection_future.dart:8:38 • (missing_default_value_for_parameter)
  error • The parameter 'controller' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/team_selection_future.dart:8:53 • (missing_default_value_for_parameter)
  error • The method '[]' can't be unconditionally invoked because the receiver can be 'null' at lib/views/mobile/team_selection_future.dart:35:24 • (unchecked_use_of_nullable_value)
  error • The parameter 'key' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/teams_dropdown.dart:8:15 • (missing_default_value_for_parameter)
  error • The parameter 'onChange' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/teams_dropdown.dart:9:26 • (missing_default_value_for_parameter)
  error • The parameter 'typeAheadController' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/mobile/teams_dropdown.dart:10:26 • (missing_default_value_for_parameter)
  error • The body might complete normally, causing 'null' to be returned, but the return type is a potentially non-nullable type at lib/views/mobile/teams_dropdown.dart:55:44 • (body_might_complete_normally)
  error • The method '[]' can't be unconditionally invoked because the receiver can be 'null' at lib/views/pc/compare_screen.dart:42:24 • (unchecked_use_of_nullable_value)
  error • Non-nullable instance field 'displayTeam' must be initialized at lib/views/pc/scatters_screen.dart:19:8 • (not_initialized_non_nullable_instance_field)
  error • Non-nullable instance field 'chosenTeam' must be initialized at lib/views/pc/team_info_screen.dart:17:13 • (not_initialized_non_nullable_instance_field)
  error • The method '[]' can't be unconditionally invoked because the receiver can be 'null' at lib/views/pc/team_info_screen.dart:36:24 • (unchecked_use_of_nullable_value)
  error • The parameter 'key' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/card.dart:6:9 • (missing_default_value_for_parameter)
  error • The parameter 'title' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/card.dart:7:20 • (missing_default_value_for_parameter)
  error • The parameter 'body' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/card.dart:8:20 • (missing_default_value_for_parameter)
  error • The parameter 'key' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/dashboard_line_chart.dart:8:9 • (missing_default_value_for_parameter)
  error • The parameter 'dataSets' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/dashboard_line_chart.dart:9:20 • (missing_default_value_for_parameter)
  error • The parameter 'colors' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/dashboard_line_chart.dart:10:10 • (missing_default_value_for_parameter)
  error • The parameter 'body' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/dashboard_scaffold.dart:7:20 • (missing_default_value_for_parameter)
  error • The parameter 'key' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/pick_list_widget.dart:7:9 • (missing_default_value_for_parameter)
  error • The parameter 'pickList' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/pick_list_widget.dart:8:20 • (missing_default_value_for_parameter)
  error • The parameter 'key' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/radar_chart.dart:8:9 • (missing_default_value_for_parameter)
  error • The parameter 'numberOfFeatures' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/radar_chart.dart:9:20 • (missing_default_value_for_parameter)
  error • The parameter 'data' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/radar_chart.dart:10:20 • (missing_default_value_for_parameter)
  error • The parameter 'ticks' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/radar_chart.dart:11:20 • (missing_default_value_for_parameter)
  error • The parameter 'features' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/radar_chart.dart:12:20 • (missing_default_value_for_parameter)
  error • The argument type 'TextStyle?' can't be assigned to the parameter type 'TextStyle' at lib/views/pc/widgets/radar_chart.dart:46:28 • (argument_type_not_assignable)
  error • The method '[]' can't be unconditionally invoked because the receiver can be 'null' at lib/views/pc/widgets/scatter.dart:60:26 • (unchecked_use_of_nullable_value)
  error • Non-nullable instance field 'teams' must be initialized at lib/views/pc/widgets/scatter.dart:71:3 • (not_initialized_non_nullable_instance_field)
  error • The parameter 'onHover' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/scatter.dart:72:20 • (missing_default_value_for_parameter)
  error • The parameter 'key' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/scatter.dart:73:9 • (missing_default_value_for_parameter)
  error • The parameter 'teams' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/scatter.dart:74:16 • (missing_default_value_for_parameter)
  error • The property 'length' can't be unconditionally accessed because the receiver can be 'null' at lib/views/pc/widgets/scatter.dart:99:41 • (unchecked_use_of_nullable_value)
  error • The method 'map' can't be unconditionally invoked because the receiver can be 'null' at lib/views/pc/widgets/scatter.dart:103:28 • (unchecked_use_of_nullable_value)
  error • The property 'spotIndex' can't be unconditionally accessed because the receiver can be 'null' at lib/views/pc/widgets/scatter.dart:125:64 • (unchecked_use_of_nullable_value)
  error • The non-nullable local variable 'tooltip' must be assigned before it can be used at lib/views/pc/widgets/scatter.dart:136:35 • (not_assigned_potentially_non_nullable_local_variable)
  error • The parameter 'key' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/scouting_specific.dart:7:9 • (missing_default_value_for_parameter)
  error • The parameter 'msg' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/scouting_specific.dart:8:20 • (missing_default_value_for_parameter)
  error • The parameter 'driveTrainType' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/team_info_data.dart:27:13 • (missing_default_value_for_parameter)
  error • The parameter 'driveMotorAmount' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/team_info_data.dart:28:12 • (missing_default_value_for_parameter)
  error • The parameter 'driveMotorType' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/team_info_data.dart:29:12 • (missing_default_value_for_parameter)
  error • The parameter 'driveTrainReliability' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/team_info_data.dart:30:12 • (missing_default_value_for_parameter)
  error • The parameter 'driveWheelType' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/team_info_data.dart:31:12 • (missing_default_value_for_parameter)
  error • The parameter 'electronicsReliability' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/team_info_data.dart:32:12 • (missing_default_value_for_parameter)
  error • The parameter 'gearbox' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/team_info_data.dart:33:12 • (missing_default_value_for_parameter)
  error • The parameter 'notes' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/team_info_data.dart:34:12 • (missing_default_value_for_parameter)
  error • The parameter 'robotReliability' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/team_info_data.dart:35:12 • (missing_default_value_for_parameter)
  error • The parameter 'shifter' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/team_info_data.dart:36:12 • (missing_default_value_for_parameter)
  error • The parameter 'url' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/team_info_data.dart:37:12 • (missing_default_value_for_parameter)
  error • The parameter 'key' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/team_info_data.dart:54:9 • (missing_default_value_for_parameter)
  error • The parameter 'team' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/team_info_data.dart:55:20 • (missing_default_value_for_parameter)
  error • The body might complete normally, causing 'null' to be returned, but the return type is a potentially non-nullable type at lib/views/pc/widgets/team_info_data.dart:65:23 • (body_might_complete_normally)
  error • The method '[]' can't be unconditionally invoked because the receiver can be 'null' at lib/views/pc/widgets/team_info_data.dart:90:38 • (unchecked_use_of_nullable_value)
  error • The method '[]' can't be unconditionally invoked because the receiver can be 'null' at lib/views/pc/widgets/team_info_data.dart:91:40 • (unchecked_use_of_nullable_value)
  error • The method '[]' can't be unconditionally invoked because the receiver can be 'null' at lib/views/pc/widgets/team_info_data.dart:92:38 • (unchecked_use_of_nullable_value)
  error • The method '[]' can't be unconditionally invoked because the receiver can be 'null' at lib/views/pc/widgets/team_info_data.dart:93:45 • (unchecked_use_of_nullable_value)
  error • The method '[]' can't be unconditionally invoked because the receiver can be 'null' at lib/views/pc/widgets/team_info_data.dart:95:38 • (unchecked_use_of_nullable_value)
  error • The method '[]' can't be unconditionally invoked because the receiver can be 'null' at lib/views/pc/widgets/team_info_data.dart:96:46 • (unchecked_use_of_nullable_value)
  error • The method '[]' can't be unconditionally invoked because the receiver can be 'null' at lib/views/pc/widgets/team_info_data.dart:98:31 • (unchecked_use_of_nullable_value)
  error • The method '[]' can't be unconditionally invoked because the receiver can be 'null' at lib/views/pc/widgets/team_info_data.dart:99:31 • (unchecked_use_of_nullable_value)
  error • The method '[]' can't be unconditionally invoked because the receiver can be 'null' at lib/views/pc/widgets/team_info_data.dart:100:29 • (unchecked_use_of_nullable_value)
  error • The method '[]' can't be unconditionally invoked because the receiver can be 'null' at lib/views/pc/widgets/team_info_data.dart:101:40 • (unchecked_use_of_nullable_value)
  error • The method '[]' can't be unconditionally invoked because the receiver can be 'null' at lib/views/pc/widgets/team_info_data.dart:102:27 • (unchecked_use_of_nullable_value)
  error • The method '[]' can't be unconditionally invoked because the receiver can be 'null' at lib/views/pc/widgets/team_info_data.dart:120:24 • (unchecked_use_of_nullable_value)
  error • The method '[]' can't be unconditionally invoked because the receiver can be 'null' at lib/views/pc/widgets/team_info_data.dart:162:24 • (unchecked_use_of_nullable_value)
  error • The property 'length' can't be unconditionally accessed because the receiver can be 'null' at lib/views/pc/widgets/team_info_data.dart:205:63 • (unchecked_use_of_nullable_value)
  error • The method '[]' can't be unconditionally invoked because the receiver can be 'null' at lib/views/pc/widgets/team_info_data.dart:210:62 • (unchecked_use_of_nullable_value)
  error • A value of type 'Object?' can't be assigned to a variable of type 'PitViewData' at lib/views/pc/widgets/team_info_data.dart:243:58 • (invalid_assignment)
  error • The property 'length' can't be unconditionally accessed because the receiver can be 'null' at lib/views/pc/widgets/team_info_data.dart:292:39 • (unchecked_use_of_nullable_value)
  error • The parameter 'key' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/teams_search_box.dart:8:15 • (missing_default_value_for_parameter)
  error • The parameter 'teams' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/teams_search_box.dart:9:26 • (missing_default_value_for_parameter)
  error • The parameter 'onChange' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/teams_search_box.dart:10:26 • (missing_default_value_for_parameter)
  error • The parameter 'typeAheadController' can't have a value of 'null' because of its type, but the implicit default value is 'null' at lib/views/pc/widgets/teams_search_box.dart:11:26 • (missing_default_value_for_parameter)
  error • The argument type 'AnimationController?' can't be assigned to the parameter type 'Animation<double>' at lib/views/pc/widgets/teams_search_box.dart:66:25 • (argument_type_not_assignable)

The migration tool didn't start, due to analysis errors.

The following steps might fix your problem:
1. Run `dart pub get`.
2. Try running `dart migrate` again.

More information: https://dart.dev/go/null-safety-migration
```
Most of these issues are trivial and should take minutes (or even seconds) to solve.
@Team1690/scouting Who's on this?