### PR TITLE
Upgrade/outdated dependencies

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -99,13 +99,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.4"
-  dropdownfield:
-    dependency: "direct main"
-    description:
-      name: dropdownfield
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.3"
   equatable:
     dependency: transitive
     description:
@@ -553,13 +546,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.10.0"
-  stepper_counter_swipe:
-    dependency: "direct main"
-    description:
-      name: stepper_counter_swipe
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.0"
   stream_channel:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,10 +23,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  stepper_counter_swipe: ^1.0.0
   percent_indicator: ^3.4.0
   progress_state_button: ^1.0.2
-  dropdownfield: ^1.0.3
   flutter_typeahead: ^3.1.3
   flutter_keyboard_visibility: ^5.0.2
   http: ^0.13.1


### PR DESCRIPTION
We had 3 dependencies that don't support null safety yet.
I've upgraded one, and the other two apparently aren't even used.