### PR TITLE
added empty on conflict in  the fetch teams script

### DIFF
--- a/scripts/fetch_teams_tba.dart
+++ b/scripts/fetch_teams_tba.dart
@@ -56,9 +56,9 @@ Future<http.Response> fetchTeamsFromTba(final String event) {
   );
 }
 
-const String mutation = """
-mutation MyMutation(\$teams: [team_insert_input!]!) {
-  insert_team(objects: \$teams) {
+const String mutation = r"""
+mutation MyMutation($teams: [team_insert_input!]!) {
+  insert_team(objects: $teams, on_conflict: {constraint: team_number_key}) {
     affected_rows
   }
 }


### PR DESCRIPTION
I did this because of what happened to tba in dis 3 when a team wasn't included and was included later in the event